### PR TITLE
make logbook more clear

### DIFF
--- a/custom_components/zigbee2mqtt_networkmap.py
+++ b/custom_components/zigbee2mqtt_networkmap.py
@@ -1,4 +1,3 @@
-# https://community.home-assistant.io/t/zigbee2mqtt-show-the-networkmap-in-hassio/89116/26
 import homeassistant.loader as loader
 from datetime import datetime
 

--- a/custom_components/zigbee2mqtt_networkmap.py
+++ b/custom_components/zigbee2mqtt_networkmap.py
@@ -1,3 +1,4 @@
+# https://community.home-assistant.io/t/zigbee2mqtt-show-the-networkmap-in-hassio/89116/26
 import homeassistant.loader as loader
 from datetime import datetime
 
@@ -13,7 +14,7 @@ def setup(hass, config):
     """Set up the Hello MQTT component."""
     mqtt = hass.components.mqtt
     topic = config[DOMAIN].get(CONF_TOPIC, DEFAULT_TOPIC)
-    entity_id = 'zigbee2mqtt_networkMap.last_update'
+    entity_id = 'zigbee2mqtt_networkmap.map_last_update'
 
     # Listener to be called when we receive a message.
     def message_received(topic, payload, qos):


### PR DESCRIPTION
Right now when the update runs it updates the entity ID zigbee2mqtt_networkmap.last_update which is fine except when viewing the logbook it's very confusing. Changing the entity ID to zigbee2mqtt_networkmap.map_last_update makes it much less confusing. 