### PR TITLE
Change webhook URLs with IDs in generated settings.js file

### DIFF
--- a/custom_components/zigbee2mqtt_networkmap/__init__.py
+++ b/custom_components/zigbee2mqtt_networkmap/__init__.py
@@ -44,18 +44,15 @@ async def async_setup(hass, config):
     webhook_trigger_update_id = hass.components.webhook.async_generate_id()
     hass.components.webhook.async_register(
         DOMAIN, 'zigbee2mqtt_networkmap-webhook_trigger_update', webhook_trigger_update_id, handle_webhook_trigger_update)
-    webhook_trigger_update_url = hass.components.webhook.async_generate_url(webhook_trigger_update_id)
 
     # Register the Webhook for trigger update
     webhook_check_update_id = hass.components.webhook.async_generate_id()
     hass.components.webhook.async_register(
         DOMAIN, 'zigbee2mqtt_networkmap-webhook_check_update', webhook_check_update_id, handle_webhook_check_update)
-    webhook_check_update_url = hass.components.webhook.async_generate_url(webhook_check_update_id)
 
     f = open(hass.config.path('www', 'community', 'zigbee2mqtt_networkmap', 'settings.js'), "w")
-    f.write("var webhook_trigger_update_url = '"+webhook_trigger_update_url+"';")
-    f.write("\n")
-    f.write("var webhook_check_update_url = '"+webhook_check_update_url+"';")
+    f.write("var webhook_trigger_update_id = '{}';\n".format(webhook_trigger_update_id))
+    f.write("var webhook_check_update_id = '{}';".format(webhook_check_update_id))
     f.close()
 
 

--- a/custom_components/zigbee2mqtt_networkmap/www/map.html
+++ b/custom_components/zigbee2mqtt_networkmap/www/map.html
@@ -92,12 +92,13 @@
     var tmpIChecks = 0;
     async function checkForUpdate() {
       try {
-        if(typeof webhook_check_update_url == 'undefined') throw "webhook_check_update_url JS var is undefined, please check the component/www folder is writable";
+        if(typeof webhook_check_update_id == 'undefined')
+          throw "webhook_check_update_id JS var is undefined, please check if <config>/www/community/zigbee2mqtt_networkmap folder is writable";
        
         document.getElementById('output').innerHTML = "Checking for graph update...";
         document.body.style.cursor = 'progress';
         var xmlhttp = new XMLHttpRequest();
-        xmlhttp.open("POST", webhook_check_update_url);
+        xmlhttp.open("POST", '/api/webhook/' + webhook_check_update_id);
         xmlhttp.setRequestHeader("Content-Type", "application/json");
         xmlhttp.send();
 
@@ -167,11 +168,13 @@
       
       // Call the Webhook, wait a few seconds til source.js is ready and then reload the page.
       try {
-        if(typeof webhook_trigger_update_url == 'undefined') throw "webhook_trigger_update_url JS var is undefined, please check the component/www folder is writable";
+        if(typeof webhook_trigger_update_id == 'undefined')
+          throw "webhook_trigger_update_id JS var is undefined, please check if <config>/www/community/zigbee2mqtt_networkmap folder is writable";
+          
             document.getElementById('output').innerHTML = "Requesting graph update...";
             document.body.style.cursor = 'progress';
             var xmlhttp = new XMLHttpRequest();
-            xmlhttp.open("POST", webhook_trigger_update_url);
+            xmlhttp.open("POST", '/api/webhook/' + webhook_trigger_update_id);
             xmlhttp.setRequestHeader("Content-Type", "application/json");
             xmlhttp.send();
             


### PR DESCRIPTION
If you run Home Assistant behind a webserver, the URLs provided by `hass.components.webhook` are not working outside local network, so I create the file `settings.js` with webhook IDs instead of URLs. The main `map.html` file will then make XMLHttpRequest using those IDs and the browser base url.