### PR TITLE
Request the networkmap includes routes

### DIFF
--- a/custom_components/zigbee2mqtt_networkmap/__init__.py
+++ b/custom_components/zigbee2mqtt_networkmap/__init__.py
@@ -91,7 +91,7 @@ async def async_setup(hass, config):
         tmpVar.received_update = False
         tmpVar.update_data = None
         tmpVar.last_update = None
-        mqtt.async_publish(topic+'/bridge/networkmap', 'graphviz')
+        mqtt.async_publish(topic+'/bridge/networkmap/routes', 'graphviz')
 
     hass.services.async_register(DOMAIN, 'update', update_service)
     return True


### PR DESCRIPTION
As described at https://www.zigbee2mqtt.io/information/mqtt_topics_and_message_structure.html, "To request a networkmap with routes use zigbee2mqtt/bridge/networkmap/routes as topic."

This change ensures that published network map includes routes.